### PR TITLE
ctx.fillrect() not working properly

### DIFF
--- a/src/patches/method.patches.ts
+++ b/src/patches/method.patches.ts
@@ -36,6 +36,8 @@ export function applyMethodPatches(context: any) {
 
           // draw functions may get filters applied and copied back to original
           if (DRAWING_FUNCTIONS.includes(member)) {
+            var strokeStyle = this.strokeStyle;
+            var fillStyle = this.fillStyle;
             // apply the filter
             applyFilter(this.canvas.__currentPathMirror, this.filter);
 
@@ -48,7 +50,8 @@ export function applyMethodPatches(context: any) {
             }
 
             // draw mirror back
-            this.drawImage(this.canvas.__currentPathMirror.canvas, 0, 0);
+            this.drawImage(this.canvas.__currentPathMirror.canvas, 0, 0, this.canvas.width, this.canvas.height);
+        
 
             // set back transforms and re-enable patch
             if (originalTransform) {
@@ -58,6 +61,7 @@ export function applyMethodPatches(context: any) {
 
             // reset the mirror for next draw cycle
             this.canvas.__currentPathMirror = createOffscreenContext(this);
+            this.strokeStyle = strokeStyle; this.fillStyle = fillStyle;
           }
 
           return result;


### PR DESCRIPTION
1. While using fillRect() on drawing, it draws at width of 300, 150 instead of canvas's width and height

 

Code Changes:

 

Bug Line:
![image](https://user-images.githubusercontent.com/95226111/228443895-f4654d6f-6966-4832-8ba0-e3175fcdae08.png)

 

Fix Line:
![image](https://user-images.githubusercontent.com/95226111/228443998-944d1832-5bd4-4eaa-8980-81380e00ca71.png)

 

2. Stroke color and fill color of context changes while calling setTransform() method in polyfill

 

Code Changes:

 

Bug:
![image](https://user-images.githubusercontent.com/95226111/228444385-09c45e4f-c598-4065-9349-32c9a014b9da.png)

 

Fix:
![image](https://user-images.githubusercontent.com/95226111/228444420-0d5607fb-6c6b-4fbe-b437-3088f5ae6e39.png)